### PR TITLE
Configure AsyncExecutor to prevent warning

### DIFF
--- a/src/main/scala/ScalatraBootstrap.scala
+++ b/src/main/scala/ScalatraBootstrap.scala
@@ -32,7 +32,15 @@ class ScalatraBootstrap extends LifeCycle {
    */
   override def init(context: ServletContext) {
     // val db = if (cpds != null) Database.forDataSource(cpds) else null
-    val db = if (cpds != null) Database.forDataSource(cpds, Option(50)) else null
+    val maxConns = ExchConfig.getInt("api.db.maxPoolSize")
+    val db =
+      if (connPool != null) {
+        Database.forDataSource(
+          connPool,
+          Some(maxConns),
+          AsyncExecutor("ExchangeExecutor", maxConns, maxConns, 1000, maxConns)
+        )
+      } else null
 
     // Disable scalatra's builtin CorsSupport because for some inexplicable reason it doesn't set Access-Control-Allow-Origin which is critical
     context.setInitParameter("org.scalatra.cors.enable", "false")

--- a/src/main/scala/ScalatraBootstrap.scala
+++ b/src/main/scala/ScalatraBootstrap.scala
@@ -34,9 +34,9 @@ class ScalatraBootstrap extends LifeCycle {
     // val db = if (cpds != null) Database.forDataSource(cpds) else null
     val maxConns = ExchConfig.getInt("api.db.maxPoolSize")
     val db =
-      if (connPool != null) {
+      if (cpds != null) {
         Database.forDataSource(
-          connPool,
+          cpds,
           Some(maxConns),
           AsyncExecutor("ExchangeExecutor", maxConns, maxConns, 1000, maxConns)
         )


### PR DESCRIPTION
See
https://github.com/slick/slick/blob/884e221b7b471efe05458ff56530f896259971da/slick/src/main/scala/slick/util/AsyncExecutor.scala#L41
for more details regarding the configuration options.