### PR TITLE
travis test failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
   POSTGRES_USER=admin EXCHANGE_FE_HEADER=issuer DOCKER_NETWORK=exchange-api-network
 before_script:
 - make .docker-network
-- docker run -d -e POSTGRES_DB=$POSTGRES_DB -e POSTGRES_USER=$POSTGRES_USER --network
+- docker run -d -e POSTGRES_HOST_AUTH_METHOD=trust -e POSTGRES_DB=$POSTGRES_DB -e POSTGRES_USER=$POSTGRES_USER --network
   $DOCKER_NETWORK --name postgres postgres
 - export POSTGRES_HOST=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'
   postgres)


### PR DESCRIPTION
The Travis tests were failing because of a postgres update in the docker library: https://github.com/docker-library/postgres/issues/681.
The fix described there is what we did just adding `-e POSTGRES_HOST_AUTH_METHOD=trust` to the docker run statement. 