### PR TITLE
update UsersSuite to not use existing mycluster org for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ target/
 
 # IntelliJ IDEA
 .idea/
+/exchange-api.iml
+/.bsp/
 
 # Eclipse?
 .classpath


### PR DESCRIPTION
After i updated my dev environment, I was getting a test failure running `UsersSuite.scala` in the tests that use my existing `mycluster` org. Since the multi-tenancy support was added, the tests can use an org of its own and set the `cloud_id` tag to the IAM account, so i changed `UsersSuite.scala` to use that.

Signed-off-by: Bruce Potter <bp@us.ibm.com>