### PR TITLE
Back Porting Fixes To Version 2.87.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,24 @@ Now you can disable root by setting `api.root.enabled` to `false` in `/etc/horiz
     - detect if a pattern is updated with service that has userInput w/o default values, and give warning
     - Consider changing all creates to POST, and update (via put/patch) return codes to 200
 
+## Changes in 2.87.1
+- This patch back ports some/all changes from the following Exchange versions:
+  - `2.90.2`
+  - `2.90.3`
+  - `2.90.4`
+  - `2.91.0`
+  - `2.92.0`
+  - `2.93.0`
+- The changes include the fixes to the following issues:
+  - Issue 547: Updated Sbt to version `1.5.6`.
+  - Issue 549: Updated Sbt to version `1.5.7`.
+  - Issue 549: Updated Sbt to version `1.6.0`.
+  - Updated Sbt to version `1.6.1`.
+  - Issue 560: Organization Administrators can now read all nodes organization wide from `orgs/{orgid}/search/nodes/service`
+  - Locked `akka-http-jackson` to version `1.37.0`.
+  - Locked Slick to version `3.3.3`.
+  - Locked Slick-PG to version `0.19.3`.
+
 ## Changes in 2.87.0
 - Translation updates
 

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ lazy val root = (project in file("."))
           "com.typesafe.akka" %% "akka-http-xml"        % "[10.2.4]",
           // "com.typesafe.akka" %% "akka-stream"          % "[2.6.14,)",
           // "com.typesafe.akka" %% "akka-http-spray-json" % "[10.2.1,)",
-          "de.heikoseeberger" %% "akka-http-jackson" % "[1.35.3,)",  // version 1.35.3 pulls in akka 2.6.10 and akkahttp 10.2.2
+          "de.heikoseeberger" %% "akka-http-jackson" % "[1.37.0]",  // version 1.35.3 pulls in akka 2.6.10 and akkahttp 10.2.2
           // "com.typesafe.akka" %% "akka-http-jackson" % "[10.2.1,)", //<- can not find any recent documentation on how to use this
           
           "org.json4s" %% "json4s-native" % "3.6.6",  // Version 3.7.0-M3 is incompatible.
@@ -62,10 +62,10 @@ lazy val root = (project in file("."))
           "io.swagger.core.v3" % "swagger-models" % "[2.1.5,)", // Version 2.1.3 causes incompatability error with Jackson Databind -- https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-models
           "io.swagger.core.v3" % "swagger-jaxrs2" % "[2.1.5,)", // Version 2.1.3 causes incompatability error with Jackson Databind -- https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-jaxrs2
   
-          "com.typesafe.slick" %% "slick" % "[3.3.3,)",
-          "com.typesafe.slick" %% "slick-hikaricp" % "[3.3.3,)",
-          "com.github.tminglei" %% "slick-pg" % "[0.19.3,)",
-          "com.github.tminglei" %% "slick-pg_json4s" % "[0.19.3,)",
+          "com.typesafe.slick" %% "slick" % "[3.3.3]",
+          "com.typesafe.slick" %% "slick-hikaricp" % "[3.3.3]",
+          "com.github.tminglei" %% "slick-pg" % "[0.19.3]",
+          "com.github.tminglei" %% "slick-pg_json4s" % "[0.19.3]",
           "org.postgresql" % "postgresql" % "42.2.19",  // Version number must be manually specified to prevent Maven from selecting a jre6/7 version of this dependency.
           //"com.zaxxer" % "HikariCP" % "[3.4.5,)",
           "org.slf4j" % "slf4j-simple" % "[1.7.30]", // Needed by scalacache, slick, and swagger.

--- a/doc/openapi-3-developer.json
+++ b/doc/openapi-3-developer.json
@@ -8,7 +8,7 @@
       "name" : "Apache License Version 2.0",
       "url" : "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version" : "2.86.0"
+    "version" : "2.87.1"
   },
   "externalDocs" : {
     "description" : "Open-horizon ExchangeAPI",

--- a/doc/openapi-3-user.json
+++ b/doc/openapi-3-user.json
@@ -8,7 +8,7 @@
       "name" : "Apache License Version 2.0",
       "url" : "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version" : "2.86.0"
+    "version" : "2.87.1"
   },
   "externalDocs" : {
     "description" : "Open-horizon ExchangeAPI",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.8
+sbt.version=1.6.1

--- a/src/main/scala/com/horizon/exchangeapi/OrgsRoutes.scala
+++ b/src/main/scala/com/horizon/exchangeapi/OrgsRoutes.scala
@@ -849,7 +849,7 @@ trait OrgsRoutes extends JacksonSupport with AuthenticationSupport {
           ident match {
             case _: IUser =>
               // if the caller is a normal user then we need to only return node the caller owns
-              if(!ident.isSuperUser || !ident.isAdmin) qFilter = qFilter.filter(_.owner === ident.identityString)
+              if(!(ident.isSuperUser || ident.isAdmin)) qFilter = qFilter.filter(_.owner === ident.identityString)
             case _ => ; // nodes can't call this route and agbots don't need an additional filter
           }
           val q = for {

--- a/src/test/scala/com/horizon/exchangeapi/NodesSuite.scala
+++ b/src/test/scala/com/horizon/exchangeapi/NodesSuite.scala
@@ -252,6 +252,8 @@ class NodesSuite extends AnyFunSuite {
     Http(URL + "/users/" + user).postData(write(PostPutUsersRequest(pw, admin = false, Some(false), user + "@hotmail.com"))).method("post").headers(CONTENT).headers(ACCEPT).headers(ROOTAUTH).asString
     
     Http(URL + "/users/u2").postData(write(PostPutUsersRequest("u2pw", admin = false, Some(false), "u2@hotmail.com"))).method("post").headers(CONTENT).headers(ACCEPT).headers(ROOTAUTH).asString
+  
+    Http(URL + "/users/u3").postData(write(PostPutUsersRequest("u3pw", admin = true, Some(false), "u3@hotmail.com"))).method("post").headers(CONTENT).headers(ACCEPT).headers(ROOTAUTH).asString
     
     assert(true)
   }
@@ -2991,6 +2993,16 @@ class NodesSuite extends AnyFunSuite {
     assert(response.body.contains(nodeId))
     assert(response.body.contains(nodeId2))
   }
+  
+  test("POST /orgs/"+orgid+"/search/nodes/service - should find " + SDRSPEC_URL + " running on 2 nodes called by an admin") {
+    val input = PostServiceSearchRequest(orgid, SDRSPEC_URL, svcversion, svcarch)
+    val response = Http(URL+"/search/nodes/service").postData(write(input)).headers(CONTENT).headers(ACCEPT).headers(("Authorization", "Basic " + ApiUtils.encode("NodesSuiteTests/u3:u3pw"))).asString
+    info("code: "+response.code+", response.body: "+response.body)
+    info("code: "+response.code)
+    assert(response.code === HttpCode.POST_OK.intValue)
+    assert(response.body.contains(nodeId))
+    assert(response.body.contains(nodeId2))
+  }
 
   // test a service that no node is running has an empty resp
   test("POST /orgs/"+orgid+"/search/nodes/service - should find " + PWSSPEC_URL + " running on 0 nodes") {
@@ -3111,7 +3123,6 @@ class NodesSuite extends AnyFunSuite {
   }
 
   // Test PATCH Nodes all attributes but token
-
   test("PATCH /orgs/"+orgid+"/nodes/"+nodeId+" - patch node w/o token") {
     val input = PatchNodesRequest(None, Some("rpi"+nodeId+"-update"), None, Some(""),
       Some(List(


### PR DESCRIPTION
- This patch back ports some/all changes from the following Exchange versions:
  - `2.90.2`
  - `2.90.3`
  - `2.90.4`
  - `2.91.0`
  - `2.92.0`
  - `2.93.0`
- The changes include the fixes to the following issues:
  - Issue 547: Updated Sbt to version `1.5.6`.
  - Issue 549: Updated Sbt to version `1.5.7`.
  - Issue 549: Updated Sbt to version `1.6.0`.
  - Updated Sbt to version `1.6.1`.
  - Issue 560: Organization Administrators can now read all nodes organization wide from `orgs/{orgid}/search/nodes/service`
  - Locked `akka-http-jackson` to version `1.37.0`.
  - Locked Slick to version `3.3.3`.
  - Locked Slick-PG to version `0.19.3`."