### PR TITLE
added option to the test suite JVM to allow these accesses to occur

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,6 +89,8 @@ lazy val root = (project in file("."))
         ), 
         scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature"),
         javacOptions ++= Seq("-source", "11", "-target", "11", "-Xlint"),
+        fork := true,
+        Test / javaOptions ++= Seq("--add-opens", "java.base/java.net=ALL-UNNAMED"),
         // Used when running test suites with HTTPS.
         // Requires path to your PKCS #12 cryptographic store and its password.
         // fork := true,


### PR DESCRIPTION
Issue #614 

In the SBT build file, I added an option to allow the unauthorized accesses that were previously causing an error.

This is kind of a dirty hotfix, but it will allow us to continue to use our current testing environment without any major changes.

This issue was likely caused by the org.scalaj:scalaj-http dependency becoming deprecated. A more substantial fix would include changing all of our HTTP requests in our test suites to use akka instead of scalaj. However, this would take a considerable amount of time/effort, so this hotfix will work for now.

Signed-off-by: Ethan Weaver <emw0022@mix.wvu.edu>