### PR TITLE
Issue #682,#688 - Bug: Actions workflow pushes docker images to GitHub con…

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -12,6 +12,7 @@ on:
 # Variables available to all jobs
 env:
   IMAGE_REPO: ${{ vars.DOCKERHUB_REPO }}
+  GITHUB_CONTAINER_REGISTRY: ghcr.io/${{ github.repository_owner }}
   BUILD_NUMBER: ${{ github.run_number }}
 
 # Jobs that will run when the workflow is triggered
@@ -26,13 +27,34 @@ jobs:
       IMAGE_VERSION: ''
     
     steps:
+      # Ensure that the repo variables and secrets are set before running any other steps
+      - name: Check User Set Variables
+        run: |
+          if [[ -z "$DOCKER_USER" ]]; then \
+          echo "::error::Secret DOCKER_USER was not set"; \
+          exit 1; \
+          fi
+          if [[ -z "$DOCKER_TOKEN" ]]; then \
+          echo "::error::Secret DOCKER_TOKEN was not set"; \
+          exit 1; \
+          fi
+          if [[ -z "$IMAGE_REPO" ]]; then \
+          echo "::error::Variable DOCKERHUB_REPO was not set"; \
+          exit 1; \
+          fi
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+
       # Upgrade Docker engine version, needed for building images.
       - name: Install Latest Docker Version
         run: |
+          sudo apt-get purge docker-ce docker-ce-cli containerd.io runc containerd moby-buildx moby-cli moby-compose moby-containerd moby-engine moby-runc
+
           curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
           sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu  $(lsb_release -cs)  stable"
           sudo apt-get update
-          sudo apt-get install docker-ce
+          sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
       # Authenticate Dockerhub to allow pushing to our image repo
       - name: Login to Dockerhub
@@ -40,6 +62,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
+        
+      # Authenticate GHCR to allow pushing to our alternate image registry
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # Checkout our Github repo
       - name: Checkout Github Repo
@@ -75,10 +105,10 @@ jobs:
       # Push Docker images to Dockerhub
       - name: Publish Image to Dockerhub
         run: |
-          docker tag openhorizon/amd64_exchange-api:${IMAGE_VERSION} ${IMAGE_REPO}/amd64_exchange-api:${IMAGE_VERSION}-${BUILD_NUMBER}
           docker tag openhorizon/amd64_exchange-api:${IMAGE_VERSION} ${IMAGE_REPO}/amd64_exchange-api:testing
-          docker push ${IMAGE_REPO}/amd64_exchange-api:${IMAGE_VERSION}-${BUILD_NUMBER}
           if [[ "$GITHUB_REF" == 'refs/heads/master' ]]; then \
           docker push ${IMAGE_REPO}/amd64_exchange-api:testing; \
+          docker tag ${IMAGE_REPO}/amd64_exchange-api:testing ${GITHUB_CONTAINER_REGISTRY}/amd64_exchange-api:testing; \
+          docker push ${GITHUB_CONTAINER_REGISTRY}/amd64_exchange-api:testing; \
           fi
       


### PR DESCRIPTION
…tainer registry, Stop pushing semantic version to dockerhub, Bug: CI Workflow failing due to Docker update step.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

- Updated our GH action workflow to stop pushing semantic version tagged images to Dockerhub.
- Updated our GH action workflow to push our testing tagged images to GitHub container registry.
- Added command to purge all old docker and moby dependencies before installing the updated versions.

**Necessary Repository Settings**
_Found in: Repo Settings -> Actions -> General_

- Workflow permissions
   - `Read and write permissions` should be selected here, this gives our ephemeral `GITHUB_TOKEN` default secret access to push to ghcr.


Fixes #682 
Fixes #688 