### PR TITLE
Maintainers Update

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,7 +5,6 @@ See the information about [community membership roles](https://wiki.lfedge.org/d
 
 | Name          | GitHub                                         | Email                     |
 |---------------|------------------------------------------------|---------------------------|
-| Bruce Potter  | [@bmpotter](https://github.com/bmpotter)       | <bp@us.ibm.com>           |
 | Lorenzo King  | [@lorenzoking](https://github.com/lorenzoking) | <Lorenzomkingiii@ibm.com> |
 | Nathan Phelps | [@naphelps](https://github.com/naphelps)       | <naphelps@us.ibm.com>     |
 | Sadiyah Faruk | [@sf2ne](https://github.com/sf2ne)             | <sf2ne@virginia.edu>      |


### PR DESCRIPTION
References:

Changes:
- Removed Bruce Potter from maintainers file following his retirement. Bruce has requested to continue as a contributor to Open Horizon.