### PR TITLE
Issue #700 - Add offset build number to Docker image version tag.

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -13,8 +13,9 @@ on:
 env:
   IMAGE_REPO: ${{ vars.DOCKERHUB_REPO }}
   GITHUB_CONTAINER_REGISTRY: ghcr.io/${{ github.repository_owner }}
-  BUILD_NUMBER: ${{ github.run_number }}
   GH_BRANCH: ${{ github.ref_name }} 
+  RUN_NUMBER: ${{ github.run_number }}
+  RUN_NUMBER_OFFSET: ${{ vars.RUN_NUMBER_OFFSET }}
 
 # Jobs that will run when the workflow is triggered
 jobs:
@@ -22,10 +23,6 @@ jobs:
   build-push:
     # The type of runner the job will run on
     runs-on: ubuntu-20.04
-
-    # Variables that are available to all steps in the job
-    env:
-      IMAGE_VERSION: ''
     
     steps:
       # Ensure that the repo variables and secrets are set before running any other steps
@@ -43,9 +40,19 @@ jobs:
           echo "::error::Variable DOCKERHUB_REPO was not set"; \
           exit 1; \
           fi
+          if [[ -z "$RUN_NUMBER_OFFSET" ]]; then \
+          echo "::error::Variable RUN_NUMBER_OFFSET was not set"; \
+          exit 1; \
+          fi
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+
+      # Offset our version build number to prevent collisions
+      - name: Offset Build Number
+        id: offset
+        run: |
+          echo "BUILD_NUMBER=$(($RUN_NUMBER + $RUN_NUMBER_OFFSET))" >> $GITHUB_ENV
 
       # Upgrade Docker engine version, needed for building images.
       - name: Install Latest Docker Version
@@ -83,9 +90,9 @@ jobs:
 
       # Configure version variables
       - name: Config Version Variables
+        id: config-version
         run: |
-          VERSION=$(head -n 1 src/main/resources/version.txt)
-          echo "IMAGE_VERSION="${VERSION}"" >> $GITHUB_ENV
+          echo "IMAGE_VERSION=$(head -n 1 src/main/resources/version.txt)-$BUILD_NUMBER" >> $GITHUB_ENV
       
       # Compile
       - name: Compile

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val root = (project in file("."))
     scalaVersion                  := "2.13.10",
     summary                       := "'Open Horizon exchange-api image'",
     vendor                        := "'Open Horizon'",
-    version                       := versionFunc(),
+    version                       := sys.env.getOrElse("IMAGE_VERSION", versionFunc()),
     // ThisBuild / scapegoatVersion := "1.4.4",
     // coverageEnabled               := false,
     
@@ -100,7 +100,7 @@ lazy val root = (project in file("."))
     //javaOptions ++= Seq("-Djava.security.auth.login.config=src/main/resources/jaas.config", "-Djava.security.policy=src/main/resources/auth.policy")
     
     // These settings are for the Docker subplugin within sbt-native-packager. See: https://sbt-native-packager.readthedocs.io/en/stable/formats/docker.html
-    Docker / version        := versionFunc(), // overwrite this setting to build a test version of the exchange with a custom tag in docker, defaults to exchange version
+    Docker / version        := sys.env.getOrElse("IMAGE_VERSION", versionFunc()), // overwrite this setting to build a test version of the exchange with a custom tag in docker, defaults to exchange version
     Docker / packageName    := "openhorizon/" ++ name.value,
     Docker / daemonUser     := "exchangeuser",
     Docker / daemonGroup    := "exchangegroup",


### PR DESCRIPTION
The Docker image tag needs to incorporate the build number in the version. This is done by setting the `IMAGE_VERSION` environment variable. If this is omitted, then the version as defined in `src/main/resources/version.txt` will be used verbatim. 

Fixes #700 