### PR TITLE
Override Guava to version 33.4.7-jre to address CVE-2023-2976

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,7 @@ lazy val root = (project in file("."))
     summary                       := "'Open Horizon exchange-api image'",
     vendor                        := "'Open Horizon'",
     version                       := sys.env.getOrElse("IMAGE_VERSION", versionFunc()),
+    dependencyOverrides += "com.google.guava" % "guava" % "33.4.7-jre",
     // ThisBuild / scapegoatVersion := "1.4.4",
     // coverageEnabled               := false,
     


### PR DESCRIPTION
### Description
A flaw was found in Guava. The methodology for temporary directories and files can allow other local users or apps with accordant permissions to access the temp files, possibly leading to information exposure or tampering in the files created in the directory.

This change forces SBT to override the transitive dependency pulled in via scalacache-guava so that it uses latest Guava version 33.4.7-jre.