### PR TITLE
block creation of user with reserved usernames 'apikey' or 'iamapikey

### DIFF
--- a/src/main/resources/messages.txt
+++ b/src/main/resources/messages.txt
@@ -391,6 +391,7 @@ user.not.found=user ''{0}'' not found
 user.not.inserted.or.updated=user ''{0}'' not inserted or updated: {1}
 user.not.updated=user not updated: {0}
 user.password.not.updated=user ''{0}'' password not updated: {1}
+user.reserved.name=The usernames 'apikey' and 'iamapikey' are reserved and cannot be used.
 user.updated.successfully=user updated successfully
 username.not.found=username not found
 version.not.valid.format=version ''{0}'' is not valid version format.

--- a/src/main/scala/org/openhorizon/exchangeapi/route/user/User.scala
+++ b/src/main/scala/org/openhorizon/exchangeapi/route/user/User.scala
@@ -174,6 +174,11 @@ trait User extends JacksonSupport with AuthenticationSupport {
           logger.debug(s"Doing POST /orgs/$organization/users/$username")
           logger.debug("isAdmin: " + identity.isAdmin + ", isHubAdmin: " + identity.isHubAdmin + ", isSuperUser: " + identity.isSuperUser)
           validateWithMsg(reqBody.getAnyProblem(identity, organization, resource, isPost = true)) {
+            val forbiddenUsernames = Set("apikey", "iamapikey")
+            if (forbiddenUsernames.contains(username.toLowerCase)) {
+            complete((HttpCode.BAD_INPUT, ApiResponse(ApiRespType.BAD_INPUT, ExchMsg.translate("user.reserved.name"))))
+            } else
+              { 
             complete({
               val updatedBy: String = identity match {
                 case IUser(identCreds) => identCreds.id;
@@ -195,7 +200,7 @@ trait User extends JacksonSupport with AuthenticationSupport {
                 case Failure(t) =>
                   (HttpCode.BAD_INPUT, ApiResponse(ApiRespType.BAD_INPUT, ExchMsg.translate("user.not.added", t.toString)))
               })
-            })
+            }) }
           }
       }
     }

--- a/src/test/scala/org/openhorizon/exchangeapi/route/user/TestPostUserRoute.scala
+++ b/src/test/scala/org/openhorizon/exchangeapi/route/user/TestPostUserRoute.scala
@@ -271,6 +271,54 @@ class TestPostUserRoute extends AnyFunSuite with BeforeAndAfterAll with BeforeAn
     assert(responseBody.msg === ExchMsg.translate("only.super.users.make.hub.admins"))
     assert(Await.result(DBCONNECTION.run(UsersTQ.filter(_.username === TESTORGS(0).orgId + "/newUser").result), AWAITDURATION).isEmpty) //insure new user wasn't added
   }
+test("POST /orgs/" + TESTORGS(0).orgId + ROUTE + "apikey -- forbidden username 'apikey' -- 400 BAD INPUT") {
+  val requestBody: PostPutUsersRequest = PostPutUsersRequest(
+      password = "newPassword",
+      admin = false,
+      hubAdmin = None,
+      email = "newUser@ibm.com"
+  )
+    val response: HttpResponse[String] = Http(URL + TESTORGS(0).orgId + ROUTE + "apikey").postData(Serialization.write(requestBody)).headers(ACCEPT).headers(CONTENT).headers(ROOTAUTH).asString
+    info("Code: " + response.code)
+    info("Body: " + response.body)
+    assert(response.code === HttpCode.BAD_INPUT.intValue)
+    val responseBody: ApiResponse = JsonMethods.parse(response.body).extract[ApiResponse]
+    assert(responseBody.msg === ExchMsg.translate("user.reserved.name"))
+    assert(Await.result(DBCONNECTION.run(UsersTQ.filter(_.username === TESTORGS(0).orgId + "/apikey").result), AWAITDURATION).isEmpty)
+}
+
+test("POST /orgs/" + TESTORGS(0).orgId + ROUTE + "iamapikey -- forbidden username 'iamapikey' -- 400 BAD INPUT") {
+  val requestBody: PostPutUsersRequest = PostPutUsersRequest(
+      password = "newPassword",
+      admin = false,
+      hubAdmin = None,
+      email = "newUser@ibm.com"
+  )
+    val response: HttpResponse[String] = Http(URL + TESTORGS(0).orgId + ROUTE + "iamapikey").postData(Serialization.write(requestBody)).headers(ACCEPT).headers(CONTENT).headers(ROOTAUTH).asString
+    info("Code: " + response.code)
+    info("Body: " + response.body)
+    assert(response.code === HttpCode.BAD_INPUT.intValue)
+    val responseBody: ApiResponse = JsonMethods.parse(response.body).extract[ApiResponse]
+    assert(responseBody.msg === ExchMsg.translate("user.reserved.name"))
+    assert(Await.result(DBCONNECTION.run(UsersTQ.filter(_.username === TESTORGS(0).orgId + "/iamapikey").result), AWAITDURATION).isEmpty)
+}
+
+test("POST /orgs/" + TESTORGS(0).orgId + ROUTE + "APIKEY -- forbidden username case-insensitive -- 400 BAD INPUT") {
+  val requestBody: PostPutUsersRequest = PostPutUsersRequest(
+      password = "newPassword",
+      admin = false,
+      hubAdmin = None,
+      email = "newUser@ibm.com"
+  )
+    val response: HttpResponse[String] = Http(URL + TESTORGS(0).orgId + ROUTE + "APIKEY").postData(Serialization.write(requestBody)).headers(ACCEPT).headers(CONTENT).headers(ROOTAUTH).asString
+    info("Code: " + response.code)
+    info("Body: " + response.body)
+    assert(response.code === HttpCode.BAD_INPUT.intValue)
+    val responseBody: ApiResponse = JsonMethods.parse(response.body).extract[ApiResponse]
+    assert(responseBody.msg === ExchMsg.translate("user.reserved.name"))
+    assert(Await.result(DBCONNECTION.run(UsersTQ.filter(_.username === TESTORGS(0).orgId + "/APIKEY").result), AWAITDURATION).isEmpty)
+}
+
 
   test("POST /orgs/root" + ROUTE + "TestPostUserRouteNewUser -- hub admin creates new hub admin -- 201 OK") {
     val requestBody: PostPutUsersRequest = PostPutUsersRequest(


### PR DESCRIPTION
Block creation of users with reserved usernames 'apikey' and 'iamapikey' (case-insensitive) via POST /orgs/{orgid}/users/{username}.

Also added unit tests to verify rejection logic.