### PR TITLE
add db fallback when using cache in UserApikey

### DIFF
--- a/src/main/scala/org/openhorizon/exchangeapi/route/apikey/UserApiKeys.scala
+++ b/src/main/scala/org/openhorizon/exchangeapi/route/apikey/UserApiKeys.scala
@@ -331,8 +331,14 @@ def userApiKeys(identity: Identity2): Route = {
           // logger.debug(s"[userApiKeys] Resolved UUID for $resource: $uuid (fromCache = $fromCache)")
           routeMethods(Some(uuid))
         case Failure(ex) =>
-          // logger.warning(s"[userApiKeys] Failed to resolve UUID for $resource: ${ex.getMessage}")
-          routeMethods(None)
+          // Retry with direct database query when cache lookup fails
+          // logger.warning(s"[userApiKeys] Cache lookup failed for $resource: ${ex.getMessage}, retrying with direct DB query")
+          onComplete(getOwnerOfResource(organization, resource, resourceType)) {
+            case Success((uuid, _)) =>
+              routeMethods(Some(uuid))
+            case Failure(retryEx) =>
+              routeMethods(None)
+        }
       }
     }
   }

--- a/src/test/scala/org/openhorizon/exchangeapi/route/apikey/TestGetApiKeyRoute.scala
+++ b/src/test/scala/org/openhorizon/exchangeapi/route/apikey/TestGetApiKeyRoute.scala
@@ -24,6 +24,7 @@ import java.util.UUID
 
 class TestGetApiKeyRoute extends AnyFunSuite with BeforeAndAfterAll {
   private val ACCEPT = ("Accept","application/json")
+  private val CONTENT: (String, String) = ("Content-Type", "application/json")
   private val AWAITDURATION: Duration = 15.seconds
   private val DBCONNECTION: jdbc.PostgresProfile.api.Database = DatabaseConnection.getDatabase
   private val PASSWORD = "password"
@@ -110,7 +111,7 @@ private val TESTORGS = Seq(
 )
 
   private val ROOTUSERID: UUID = {
-    val rootUserQuery = UsersTQ.filter(_.username === "root").result.headOption
+    val rootUserQuery = UsersTQ.filter((u => u.username === "root" && u.organization === "root")).result.headOption
     Await.result(DBCONNECTION.run(rootUserQuery), AWAITDURATION).get.user
   }
 
@@ -241,6 +242,10 @@ private val TESTORGS = Seq(
     Await.ready(DBCONNECTION.run(
       OrgsTQ.filter(_.orgid startsWith "testGetUserApiKeyOrg").delete
     ), AWAITDURATION)
+
+    val response: HttpResponse[String] = Http(sys.env.getOrElse("EXCHANGE_URL_ROOT", "http://localhost:8080") + "/v1/admin/clearauthcaches").method("POST").headers(ACCEPT).headers(CONTENT).headers(ROOTUSERAUTH).asString
+      info("Code: " + response.code)
+      info("Body: " + response.body)
   }
 
 

--- a/src/test/scala/org/openhorizon/exchangeapi/route/apikey/TestPostApiKeyRoute.scala
+++ b/src/test/scala/org/openhorizon/exchangeapi/route/apikey/TestPostApiKeyRoute.scala
@@ -26,6 +26,7 @@ import java.util.UUID
 
 class TestPostApiKeyRoute extends AnyFunSuite with BeforeAndAfterAll {
   private val ACCEPT = ("Accept","application/json")
+  private val CONTENT: (String, String) = ("Content-Type", "application/json")
   private val AWAITDURATION: Duration = 15.seconds
   private val DBCONNECTION: jdbc.PostgresProfile.api.Database = DatabaseConnection.getDatabase
   private val URL = sys.env.getOrElse("EXCHANGE_URL_ROOT", "http://localhost:8080") + "/v1/orgs/"
@@ -138,6 +139,10 @@ private val TESTUSERS = Seq(
     Await.ready(DBCONNECTION.run(
       OrgsTQ.filter(_.orgid startsWith "testPostApiKeyRouteOrg").delete
     ), AWAITDURATION)
+
+    val response: HttpResponse[String] = Http(sys.env.getOrElse("EXCHANGE_URL_ROOT", "http://localhost:8080") + "/v1/admin/clearauthcaches").method("POST").headers(ACCEPT).headers(CONTENT).headers(ROOTUSERAUTH).asString
+      info("Code: " + response.code)
+      info("Body: " + response.body)
   }
 
   // User creates their own API key - Expected: 201


### PR DESCRIPTION
issue #793

Currrently, UserApikey only rely on caching. This PR add a DB fallback to avoid possible cache read timing problem.

Also add cache clear to UTs.

Krystian have helped verify that this delay is solved with this image.